### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/example/12_http_client.dart
+++ b/example/12_http_client.dart
@@ -8,7 +8,7 @@ main() async {
   print('have request');
   var response = await request.close();
   print('have response');
-  var data = await response.transform(utf8.decoder).toList();
+  var data = await utf8.decoder.bind(response).toList();
   var body = data.join('');
   print(body);
   httpClient.close();


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
